### PR TITLE
Missing instance ID as third argument

### DIFF
--- a/github-projects@morgan-design.com/applet.js
+++ b/github-projects@morgan-design.com/applet.js
@@ -36,14 +36,14 @@ const NotificationMessages = {
 };
 
 /* Application Hook */
-function main(metadata, orientation) {
-	let myApplet = new MyApplet(metadata, orientation);
+function main(metadata, orientation, instance_id) {
+	let myApplet = new MyApplet(metadata, orientation, instance_id);
 	return myApplet;
 }
 
 /* Constructor */
-function MyApplet(metadata, orientation) {
-	this._init(metadata, orientation);
+function MyApplet(metadata, orientation, instance_id) {
+	this._init(metadata, orientation, instance_id);
 }
 
 MyApplet.prototype = {


### PR DESCRIPTION
I had a warning message in LookingGlass : Missing instance ID as third argument
![warning_github-projects](https://f.cloud.github.com/assets/5185939/1575309/6408025a-514c-11e3-9ceb-cd7b8d2a7a3e.png)
